### PR TITLE
Update welcome message in signup steps to reflect app name

### DIFF
--- a/lib/signup/widgets/signup_steps.dart
+++ b/lib/signup/widgets/signup_steps.dart
@@ -47,9 +47,9 @@ typedef StepCallback =
 List<SignupStep> signupSteps = [
   // Create initial step that plays the cooked rive animation
   SignupStep(
-    title: 'Welcome to app!',
+    title: 'Welcome to TutorLM!',
     dialogue: [
-      'Welcome to app, the app that connects students with tutors!',
+      'Welcome to TutorLM, the app that connects students with tutors!',
       'We are excited to have you here!',
       'Let\'s get started with your signup process!',
     ],


### PR DESCRIPTION
## Status

**READY**

## Description

This pull request updates the introductory text in the `signupSteps` list to reflect the app's branding as "TutorLM." The changes ensure consistency in the app's name and messaging.

Branding updates:

* [`lib/signup/widgets/signup_steps.dart`](diffhunk://#diff-7a35ffbd97d31bcf5a1206ebd415b6f2669ab6ed1861c4937c4ec938a08bb865L50-R52): Updated the `title` and `dialogue` fields in the initial `SignupStep` to replace "app" with "TutorLM" for clearer branding and a more personalized user experience.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
